### PR TITLE
Feature/feedback loop

### DIFF
--- a/simulator/hospital_queue/queue_simulation.py
+++ b/simulator/hospital_queue/queue_simulation.py
@@ -364,7 +364,7 @@ def run_queue_simulation(data, params={}):
             plt.legend()
             plt.show()
             
-            # Plot queue for beds
+            # Plot queue for ICU beds
 
             plt.plot(self.audit_report['Time'],
                     self.audit_report['ICU_Queue'],
@@ -569,104 +569,200 @@ def run_queue_simulation(data, params={}):
                     after_is_icu = 1 if random.uniform(0, 1) > (1-g.icu_after_bed) else 0
                     
                     if after_is_icu == 1:
-                        
-                        with self.resources_icu.icu_beds.request() as icu_req:
-                        
-                            # Increment queue count
-                            self.hospital.queue_icu_count += 1
-                            #print('Patient %d waiting in icu queue %7.2f, queue icu count %d' %(p.id,self.env.now,self.hospital.queue_icu_count))
-                        
-                            # Add patient to dictionary of icu queuing patients. This is not used
-                            # further in this model.
-                            self.hospital.patients_in_icu_queue[p.id] = p
-                        
-                            # Yield resource request. Sim continues after yield when resources
-                            # are vailable (so there is no delay if resources are immediately
-                            # available)
-                            yield icu_req
-                        
-                            # Resource now available. Remove from queue count and dictionary of
-                            # queued objects
-                            self.hospital.bed_count -= 1
-                            del self.hospital.patients_in_beds[p.id]
-                            #print('Patient %d leaving bed %7.2f, queue bed %d' %(p.id,self.env.now,self.hospital.bed_count))
-                        
-                            # Increment queue count
-                            self.hospital.queue_icu_count -= 1
-                            del self.hospital.patients_in_icu_queue[p.id]
-                            #print('Patient %d leaving icu queue %7.2f, queue icu count %d' %(p.id,self.env.now,self.hospital.queue_icu_count))
-                        
-                            # Add to count of patients in icu beds and to dictionary of patients in
-                            # icu beds
-                            self.hospital.patients_in_icu_beds[p.id] = p
-                            self.hospital.bed_icu_count += 1
-                            #print('Patient %d arriving icu bed %7.2f, icu bed count %d' %(p.id,self.env.now,self.hospital.bed_icu_count))
-                            
-                            self.hospital.bedToICU += 1
-                            
-                            # Trigger length of stay delay
-                            yield self.env.timeout(p.los_uti)
-                    
-                            # Length of stay complete. Remove patient from counts and
-                            # dictionaries
-                            self.hospital.bed_icu_count -= 1
-                            #print('Patient %d leaving icu bed %7.2f, icu bed count %d' %(p.id,self.env.now,self.hospital.bed_icu_count))
-                            del self.hospital.patients_in_icu_beds[p.id]
-                            del self.hospital.patients[p.id]
-                            self.hospital.releases_ICU += 1
-                            
-                    else:
-                        
+
+                        # Increment queue count
+                        self.hospital.queue_icu_count += 1
+                        #print('Patient %d waiting in icu queue %7.2f, queue icu count %d' %(p.id,self.env.now,self.hospital.queue_icu_count))
+
+                        # Add patient to dictionary of icu queuing patients. This is not used
+                        # further in this model.
+                        self.hospital.patients_in_icu_queue[p.id] = p
+
+                        # Yield resource request. Sim continues after yield when resources
+                        # are vailable (so there is no delay if resources are immediately
+                        # available)
+
+                        #TODO: review bed request with priority
+                        icu_req = self.resources_icu.icu_beds.request(priority = 1)
+                        yield icu_req
+
+                        # Resource now available. Remove from queue count and dictionary of
+                        # queued objects
+                        self.hospital.bed_count -= 1
+                        del self.hospital.patients_in_beds[p.id]
+                        #TODO: review bed release
+                        self.resources.beds.release(req)
+                        #print('Patient %d leaving bed %7.2f, queue bed %d' %(p.id,self.env.now,self.hospital.bed_count))
+
+                        # Increment queue count
+                        self.hospital.queue_icu_count -= 1
+                        del self.hospital.patients_in_icu_queue[p.id]
+                        #print('Patient %d leaving icu queue %7.2f, queue icu count %d' %(p.id,self.env.now,self.hospital.queue_icu_count))
+
+                        # Add to count of patients in icu beds and to dictionary of patients in
+                        # icu beds
+                        self.hospital.patients_in_icu_beds[p.id] = p
+                        self.hospital.bed_icu_count += 1
+                        #print('Patient %d arriving icu bed %7.2f, icu bed count %d' %(p.id,self.env.now,self.hospital.bed_icu_count))
+
+                        self.hospital.bedToICU += 1
+
+                        # Trigger length of stay delay
+                        yield self.env.timeout(p.los_uti)
+
+                        #TODO: Review pacients returning to regular beds
+                        # <---
+                        # Returns to bed 
+
+                        # Increment queue count
+                        self.hospital.queue_count += 1
+                        print('Patient %d arriving queue %7.2f, queue count %d' %(p.id,self.env.now,self.hospital.queue_count))
+                        #print('Occupied Beds %d'%(self.hospital.bed_count))
+
+                        # Add patient to dictionary of queuing patients. This is not used
+                        # further in this model.
+                        self.hospital.patients_in_queue[p.id] = p
+
+                        # Yield resource request. Sim continues after yield when resources
+                        # are vailable (so there is no delay if resources are immediately
+                        # available)
+                        req = self.resources.beds.request(priority = 1)
+                        yield req
+
+                        # Resource now available. Remove from queue count and dictionary of
+                        # queued objects
+                        self.hospital.queue_count -= 1
+                        del self.hospital.patients_in_queue[p.id]
+                        #print('Patient %d leaving queue %7.2f, queue count %d' %(p.id,self.env.now,self.hospital.queue_count))
+                        # --->
+                        self.hospital.bed_icu_count -= 1
+                        #print('Patient %d leaving icu bed %7.2f, icu bed count %d' %(p.id,self.env.now,self.hospital.bed_icu_count))
+                        del self.hospital.patients_in_icu_beds[p.id]
+                        self.resources_icu.icu_beds.release(icu_req)
+                        self.hospital.releases_ICU += 1
+
+                        #TODO: Review pacient conut
+                        # <---
+                        # Add to count of patients in beds and to dictionary of patients in
+                        # beds
+                        self.hospital.patients_in_beds[p.id] = p
+                        self.hospital.bed_count += 1
+                        #print('Patient %d arriving bed %7.2f, bed count %d' %(p.id,self.env.now,self.hospital.bed_count))
+
+                        self.hospital.ICUToBed += 1
+
+                        # Trigger length of stay delay
+                        yield self.env.timeout(p.los)
+
                         # Length of stay complete. Remove patient from counts and
                         # dictionaries
                         self.hospital.bed_count -= 1
                         #print('Patient %d leaving bed %7.2f, bed count %d' %(p.id,self.env.now,self.hospital.bed_count))
+                        print('Patient %d released %7.2f, bed count %d' %(p.id,self.env.now,self.hospital.bed_count))
                         del self.hospital.patients_in_beds[p.id]
+                        self.resources.beds.release(req)
+                        del self.hospital.patients[p.id]
                         self.hospital.releases += 1
-                    
+                        # --->
+                    else:
+
+                        # Length of stay complete. Remove patient from counts and
+                        # dictionaries
+                        self.hospital.bed_count -= 1
+                        #print('Patient %d leaving bed %7.2f, bed count %d' %(p.id,self.env.now,self.hospital.bed_count))
+                        #print('Patient %d released %7.2f, bed count %d' %(p.id,self.env.now,self.hospital.bed_count))
+                        del self.hospital.patients_in_beds[p.id]
+                        #TODO: review bed release
+                        self.resources.beds.release(req)
+                        del self.hospital.patients[p.id]
+                        self.hospital.releases += 1
+                        
             # icu bed
             else:
                 
-                self.hospital.admissions_icu += 1
-                
-                with self.resources_icu.icu_beds.request() as icu_req:
-                    
+                    self.hospital.admissions_icu += 1
+
                     # Increment queue count
                     self.hospital.queue_icu_count += 1
                     #print('Patient %d arriving icu queue %7.2f, queue icu count %d' %(p.id,self.env.now,self.hospital.queue_icu_count))
                     #print('Occupied Beds %d'%(self.hospital.bed_icu_count))
-                    
+
                     # Add patient to dictionary of icu queuing patients. This is not used
                     # further in this model.
                     self.hospital.patients_in_icu_queue[p.id] = p
-                    
+
                     # Yield resource request. Sim continues after yield when resources
                     # are vailable (so there is no delay if resources are immediately
                     # available)
+                    #TODO: review paciente priority
+                    icu_req = self.resources_icu.icu_beds.request(priority = 2)
                     yield icu_req
-                    
+
                     # Resource now available. Remove from queue count and dictionary of
                     # queued objects
                     self.hospital.queue_icu_count -= 1
                     del self.hospital.patients_in_icu_queue[p.id]
                     #print('Patient %d leaving icu queue %7.2f, icu queue count %d' %(p.id,self.env.now,self.hospital.queue_icu_count))
-                    
+
                     # Add to count of patients in icu beds and to dictionary of patients in
                     # icu beds
                     self.hospital.patients_in_icu_beds[p.id] = p
                     self.hospital.bed_icu_count += 1
                     #print('Patient %d arriving icu bed %7.2f, icu bed count %d' %(p.id,self.env.now,self.hospital.bed_icu_count))
-                    
+
                     # Trigger length of stay delay
                     yield self.env.timeout(p.los_uti)
-                    
-                    # Length of stay complete. Remove patient from counts and
-                    # dictionaries
+
+                    #TODO: review pacients going to bed
+                    # Goes to bed 
+
+                    # Increment queue count
+                    self.hospital.queue_count += 1
+                    print('Patient %d arriving queue %7.2f, queue count %d' %(p.id,self.env.now,self.hospital.queue_count))
+                    #print('Occupied Beds %d'%(self.hospital.bed_count))
+
+                    # Add patient to dictionary of queuing patients. This is not used
+                    # further in this model.
+                    self.hospital.patients_in_queue[p.id] = p
+
+                    # Yield resource request. Sim continues after yield when resources
+                    # are vailable (so there is no delay if resources are immediately
+                    # available)
+                    req = self.resources.beds.request(priority = 1)
+                    yield req
+
+                    # Resource now available. Remove from queue count and dictionary of
+                    # queued objects
+                    self.hospital.queue_count -= 1
+                    del self.hospital.patients_in_queue[p.id]
+                    #print('Patient %d leaving queue %7.2f, queue count %d' %(p.id,self.env.now,self.hospital.queue_count))
                     self.hospital.bed_icu_count -= 1
                     #print('Patient %d leaving icu bed %7.2f, icu bed count %d' %(p.id,self.env.now,self.hospital.bed_icu_count))
                     del self.hospital.patients_in_icu_beds[p.id]
-                    del self.hospital.patients[p.id]
+                    self.resources_icu.icu_beds.release(icu_req)
                     self.hospital.releases_ICU += 1
+
+                    #TODO: review
+                    # Add to count of patients in beds and to dictionary of patients in
+                    # beds
+                    self.hospital.patients_in_beds[p.id] = p
+                    self.hospital.bed_count += 1
+                    #print('Patient %d arriving bed %7.2f, bed count %d' %(p.id,self.env.now,self.hospital.bed_count))
+
+                    self.hospital.ICUToBed += 1
+
+                    # Trigger length of stay delay
+                    yield self.env.timeout(p.los)
+
+                    # Length of stay complete. Remove patient from counts and
+                    # dictionaries
+                    self.hospital.bed_count -= 1
+                    #print('Patient %d leaving bed %7.2f, bed count %d' %(p.id,self.env.now,self.hospital.bed_count))
+                    print('Patient %d released %7.2f, bed count %d' %(p.id,self.env.now,self.hospital.bed_count))
+                    del self.hospital.patients_in_beds[p.id]
+                    self.resources.beds.release(req)
+                    del self.hospital.patients[p.id]
+                    self.hospital.releases += 1
                     
             return
         
@@ -758,16 +854,7 @@ def run_queue_simulation(data, params={}):
         return
         
     # In[26]:
-    ## Code entry point. Calls main method.
-    #if __name__ == '__main__':
-    #    main()
-    # In[27]:
-    #model = Model()
     seed(98989)
     model = Model()
     model.run()
     return model.hospital.build_audit_report()
-    #model.hospital.build_audit_report().head()
-    #model.hospital.build_audit_report().to_csv('simulation.csv')
-    #model.hospital.build_audit_report().tail()
-    #odel.hospital.chart()


### PR DESCRIPTION
1. In the previous version, a patient transferred between beds would not release the former bed, thus using two resources at the same time. This would distort the occupied_beds count. This problem apparently is corrected. Occupied_beds and ICU_Occupied_beds now saturate at 9777 and 3392 respectively.

2. A patient occupying an ICU bed now always returns to a normal bed before being released. The values of ICU_releases and ICUToBed thus coincide.

3. Patients going from ICU to a regular bed only leaves the ICU once a new bed is available. The same is valid for transferring in the opposite direction.

4. New patients are now put in queue with priority 2. Established patients being transferred between ICU and beds have priority 1, and so are put at the beggining of the queue. Such priority queuing can observed at the following log:

Patient 19805 arriving queue 56.48, queue count 2
Patient 19806 arriving queue 56.48, queue count 3
Patient 19807 arriving queue 56.48, queue count 4
Patient 16113 released 56.48, bed count 9776
Patient 19804 leaving queue 56.48, queue count 3
Patient 19808 arriving queue 56.48, queue count 4
Patient 19809 arriving queue 56.48, queue count 5
Patient 19810 arriving queue 56.48, queue count 6
Patient 19811 arriving queue 56.48, queue count 7
Patient 17647 arriving queue 56.48, queue count 8
Patient 12122 released 56.48, bed count 9776
Patient 17647 leaving queue 56.48, queue count 7
Patient 16373 arriving queue 56.48, queue count 8
Patient 19812 arriving queue 56.48, queue count 9
Patient 19813 arriving queue 56.48, queue count 10
Patient 4287 released 56.48, bed count 9776
Patient 16373 leaving queue 56.48, queue count 9
Patient 6128 arriving queue 56.48, queue count 10
Patient 11414 released 56.48, bed count 9776
Patient 6128 leaving queue 56.48, queue count 9
Patient 19814 arriving queue 56.48, queue count 10
Patient 19815 arriving queue 56.48, queue count 11
Patient 19816 arriving queue 56.49, queue count 12
Patient 19817 arriving queue 56.49, queue count 13
Patient 18946 released 56.49, bed count 9776
Patient 19805 leaving queue 56.49, queue count 12
Patient 4643 released 56.49, bed count 9776
Patient 19806 leaving queue 56.49, queue count 11
